### PR TITLE
reposition search icon for larger screens

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -118,3 +118,10 @@
 //     fill: navy;
 //   }
 // }
+
+@media(min-width: 640px) {
+  .mapboxgl-ctrl-geocoder--icon-search {
+    top: 9px;
+  }
+
+}


### PR DESCRIPTION
Added media query so map search icon is centered correctly on large screens
