### PR TITLE
stop navbar from flipping around on non-mobile screen

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -8,9 +8,9 @@
 <% end %>
 
 <% if current_page?(root_path) || current_page?(map_path) %>
-  <div class="navbar navbar-expand-sm navbar-dark navbar-lewagon">
+  <div class="navbar navbar-expand-sm-md-lg navbar-dark navbar-lewagon">
 <% else %>
-  <div class="navbar navbar-expand-sm navbar-dark navbar-lewagon" style="background-color: #101010; z-index: 1000;">
+  <div class="navbar navbar-expand-sm-md-lg navbar-dark navbar-lewagon" style="background-color: #101010; z-index: 1000;">
 <% end %>
 
 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
1. Add bootstrap class for navbar so it doesn't flip around on non-mobile screen.
  navbar-expand-sm**-md-lg**

2. Change opengraph image to screenshot as old one wasn't displaying on LinkedIn properly

@odealtry
@juagarca 
@betharms 